### PR TITLE
v0.10.6 - Efficient snapshot caching. Name tags

### DIFF
--- a/ebs_snapper/__init__.py
+++ b/ebs_snapper/__init__.py
@@ -25,7 +25,7 @@ import logging
 import sys
 
 __title__ = 'ebs_snapper'
-__version__ = '0.10.5'
+__version__ = '0.10.6'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2015-2017'
 __url__ = 'https://github.com/rackerlabs/ebs-snapper-lambda-v2'


### PR DESCRIPTION
Adds a snapshot cache to avoid repeated describe_snapshots calls.  Improves performance by around 10x iterating through snapshots... avoids the lambda 15m limit.
Adds name tags to replicated snapshots.